### PR TITLE
Python 3 compatibility

### DIFF
--- a/src/bar.c
+++ b/src/bar.c
@@ -616,8 +616,7 @@ static PyMethodDef Bar_methods[] = {
 };
 
 PyTypeObject BarType = {
-  PyObject_HEAD_INIT(NULL)
-  0,					/* ob_size */
+  PyVarObject_HEAD_INIT(NULL, 0)
   "glpk.Bar",				/* tp_name */
   sizeof(BarObject),			/* tp_basicsize*/
   0,					/* tp_itemsize*/

--- a/src/bar.c
+++ b/src/bar.c
@@ -17,6 +17,8 @@ You should have received a copy of the GNU General Public License
 along with PyGLPK.  If not, see <http://www.gnu.org/licenses/>.
 **************************************************************************/
 
+#include "py3k.h"
+
 #include "bar.h"
 #include "structmember.h"
 #include "util.h"

--- a/src/bar.c
+++ b/src/bar.c
@@ -49,7 +49,7 @@ static void Bar_dealloc(BarObject *self) {
   }
   Py_DECREF(self->py_bc);
 #endif
-  self->ob_type->tp_free((PyObject*)self);
+  Py_TYPE(self)->tp_free((PyObject*)self);
 }
 
 /** Create a new bar collection object. */
@@ -80,7 +80,7 @@ BarObject *Bar_New(BarColObject *py_bc, int index) {
 static PyObject* Bar_Str(BarObject *self) {
   // Returns a string representation of this object.
   return PyString_FromFormat
-    ("<%s, %s %d of %s %p>", self->ob_type->tp_name,
+    ("<%s, %s %d of %s %p>", Py_TYPE(self)->tp_name,
      Bar_Row(self)?"row":"col", Bar_Index(self),
      LPXType.tp_name, self->py_bc->py_lp);
 }

--- a/src/barcol.c
+++ b/src/barcol.c
@@ -78,8 +78,7 @@ static PySequenceMethods bciter_as_sequence = {
 };
 
 PyTypeObject BarColIterType = {
-  PyObject_HEAD_INIT(NULL)
-  0,					/* ob_size */
+  PyVarObject_HEAD_INIT(NULL, 0)
   "glpk.BarCollectionIter",		/* tp_name */
   sizeof(BarColIterObject),		/* tp_basicsize */
   0,					/* tp_itemsize */
@@ -446,8 +445,7 @@ static PyMethodDef BarCol_methods[] = {
 };
 
 PyTypeObject BarColType = {
-  PyObject_HEAD_INIT(NULL)
-  0,					/* ob_size */
+  PyVarObject_HEAD_INIT(NULL, 0)
   "glpk.BarCollection",			/* tp_name */
   sizeof(BarColObject),			/* tp_basicsize*/
   0,					/* tp_itemsize*/

--- a/src/barcol.c
+++ b/src/barcol.c
@@ -17,6 +17,8 @@ You should have received a copy of the GNU General Public License
 along with PyGLPK.  If not, see <http://www.gnu.org/licenses/>.
 **************************************************************************/
 
+#include "py3k.h"
+
 #include "barcol.h"
 #include "bar.h"
 #include "util.h"

--- a/src/barcol.c
+++ b/src/barcol.c
@@ -56,7 +56,7 @@ static void BarColIter_dealloc(BarColIterObject *it) {
     PyObject_ClearWeakRefs((PyObject*)it);
   }
   Py_XDECREF(it->bc);
-  it->ob_type->tp_free((PyObject*)it);
+  Py_TYPE(it)->tp_free((PyObject*)it);
 }
 
 static Py_ssize_t BarColIter_len(BarColIterObject *it) {
@@ -135,7 +135,7 @@ static int BarCol_clear(BarColObject *self) {
 static void BarCol_dealloc(BarColObject *self) {
   BarCol_clear(self);
   //printf("dealloc bar col!\n");
-  self->ob_type->tp_free((PyObject*)self);
+  Py_TYPE(self)->tp_free((PyObject*)self);
 }
 
 /** Create a new bar collection object. */
@@ -392,7 +392,7 @@ static int BarCol_ass_item(BarColObject *self, int index, PyObject *v) {
 static PyObject* BarCol_Str(BarColObject *self) {
   // Returns a string representation of this object.
   return PyString_FromFormat
-    ("<%s, %s of %s %p>", self->ob_type->tp_name,
+    ("<%s, %s of %s %p>", Py_TYPE(self)->tp_name,
      (BarCol_Rows(self)?"rows":"cols"),
      LPXType.tp_name, self->py_lp);
 }

--- a/src/environment.c
+++ b/src/environment.c
@@ -253,8 +253,7 @@ static PyMethodDef Environment_methods[] = {
 };
 
 PyTypeObject EnvironmentType = {
-  PyObject_HEAD_INIT(NULL)
-  0,					/* ob_size */
+  PyVarObject_HEAD_INIT(NULL, 0)
   "glpk.Environment",			/* tp_name */
   sizeof(EnvironmentObject),		/* tp_basicsize*/
   0,					/* tp_itemsize*/

--- a/src/environment.c
+++ b/src/environment.c
@@ -39,7 +39,7 @@ static int Environment_clear(EnvironmentObject *self) {
 
 static void Environment_dealloc(EnvironmentObject *self) {
   Environment_clear(self);
-  self->ob_type->tp_free((PyObject*)self);
+  Py_TYPE(self)->tp_free((PyObject*)self);
 }
 
 EnvironmentObject* Environment_New(void) {

--- a/src/environment.c
+++ b/src/environment.c
@@ -212,7 +212,7 @@ int Environment_InitType(PyObject *module) {
 }
 
 static PyMemberDef Environment_members[] = {
-  {"version", T_OBJECT_EX, offsetof(EnvironmentObject, version), RO,
+  {"version", T_OBJECT_EX, offsetof(EnvironmentObject, version), READONLY,
    "Tuple holding the major version and minor version of the GLPK\n"
    "that this PyGLPK module was built upon.  For example, if built\n"
    "against GLPK 4.31, version==(4,31)."},

--- a/src/environment.c
+++ b/src/environment.c
@@ -17,6 +17,8 @@ You should have received a copy of the GNU General Public License
 along with PyGLPK.  If not, see <http://www.gnu.org/licenses/>.
 **************************************************************************/
 
+#include "py3k.h"
+
 #include "environment.h"
 #include "structmember.h"
 #include "util.h"

--- a/src/glpk.c
+++ b/src/glpk.c
@@ -64,7 +64,7 @@ problem and ultimately solve it.  See help on the LPX class,\n\
 as well as the HTML documentation accompanying your PyGLPK\n\
 distribution.";
 
-MOD_INIT(void)
+MOD_INIT(glpk)
 {
   PyObject *m;
   

--- a/src/glpk.c
+++ b/src/glpk.c
@@ -47,6 +47,10 @@ along with PyGLPK.  If not, see <http://www.gnu.org/licenses/>.
 
 #endif
 
+#ifndef Py_TYPE
+  #define Py_TYPE(ob) (((PyObject*)(ob))->ob_type)
+#endif
+
 static PyMethodDef GLPKMethods[] = {
   {NULL, NULL, 0, NULL}
 };

--- a/src/kkt.c
+++ b/src/kkt.c
@@ -76,24 +76,24 @@ int KKT_InitType(PyObject *module) {
 }
 
 static PyMemberDef KKT_members[] = {
-  {"pe_ae_max", T_DOUBLE, offsetof(KKTObject, kkt.pe_ae_max),  RO,
+  {"pe_ae_max", T_DOUBLE, offsetof(KKTObject, kkt.pe_ae_max),  READONLY,
    "Largest absolute error."},
-  {"pe_re_max", T_DOUBLE, offsetof(KKTObject, kkt.pe_re_max),  RO,
+  {"pe_re_max", T_DOUBLE, offsetof(KKTObject, kkt.pe_re_max),  READONLY,
    "Largest relative error."},
 
-  {"pb_ae_max", T_DOUBLE, offsetof(KKTObject, kkt.pb_ae_max),  RO,
+  {"pb_ae_max", T_DOUBLE, offsetof(KKTObject, kkt.pb_ae_max),  READONLY,
    "Largest absolute error."},
-  {"pb_re_max", T_DOUBLE, offsetof(KKTObject, kkt.pb_re_max),  RO,
+  {"pb_re_max", T_DOUBLE, offsetof(KKTObject, kkt.pb_re_max),  READONLY,
    "Largest relative error."},
 
-  {"de_ae_max", T_DOUBLE, offsetof(KKTObject, kkt.de_ae_max),  RO,
+  {"de_ae_max", T_DOUBLE, offsetof(KKTObject, kkt.de_ae_max),  READONLY,
    "Largest absolute error."},
-  {"de_re_max", T_DOUBLE, offsetof(KKTObject, kkt.de_re_max),  RO,
+  {"de_re_max", T_DOUBLE, offsetof(KKTObject, kkt.de_re_max),  READONLY,
    "Largest relative error."},
 
-  {"db_ae_max", T_DOUBLE, offsetof(KKTObject, kkt.db_ae_max),  RO,
+  {"db_ae_max", T_DOUBLE, offsetof(KKTObject, kkt.db_ae_max),  READONLY,
    "Largest absolute error."},
-  {"db_re_max", T_DOUBLE, offsetof(KKTObject, kkt.db_re_max),  RO,
+  {"db_re_max", T_DOUBLE, offsetof(KKTObject, kkt.db_re_max),  READONLY,
    "Largest relative error."},
   {NULL}
 };

--- a/src/kkt.c
+++ b/src/kkt.c
@@ -25,7 +25,7 @@ static void KKT_dealloc(KKTObject *self) {
   if (self->weakreflist != NULL) {
     PyObject_ClearWeakRefs((PyObject*)self);
   }
-  self->ob_type->tp_free((PyObject*)self);
+  Py_TYPE(self)->tp_free((PyObject*)self);
 }
 
 /** Create a new parameter collection object. */

--- a/src/kkt.c
+++ b/src/kkt.c
@@ -139,8 +139,7 @@ static PyMethodDef KKT_methods[] = {
 };
 
 PyTypeObject KKTType = {
-  PyObject_HEAD_INIT(NULL)
-  0,					/* ob_size */
+  PyVarObject_HEAD_INIT(NULL, 0)
   "glpk.KKT",				/* tp_name */
   sizeof(KKTObject),			/* tp_basicsize*/
   0,					/* tp_itemsize*/

--- a/src/kkt.c
+++ b/src/kkt.c
@@ -17,6 +17,8 @@ You should have received a copy of the GNU General Public License
 along with PyGLPK.  If not, see <http://www.gnu.org/licenses/>.
 **************************************************************************/
 
+#include "py3k.h"
+
 #include "util.h"
 #include "kkt.h"
 #include "structmember.h"

--- a/src/lp.c
+++ b/src/lp.c
@@ -17,6 +17,8 @@ You should have received a copy of the GNU General Public License
 along with PyGLPK.  If not, see <http://www.gnu.org/licenses/>.
 **************************************************************************/
 
+#include "py3k.h"
+
 #include "lp.h"
 #include "structmember.h"
 #include "barcol.h"

--- a/src/lp.c
+++ b/src/lp.c
@@ -931,12 +931,12 @@ int LPX_InitType(PyObject *module) {
 }
 
 static PyMemberDef LPX_members[] = {
-  {"rows", T_OBJECT_EX, offsetof(LPXObject, rows), RO,
+  {"rows", T_OBJECT_EX, offsetof(LPXObject, rows), READONLY,
    "Row collection.  See the help on class BarCollection."},
-  {"cols", T_OBJECT_EX, offsetof(LPXObject, cols), RO,
+  {"cols", T_OBJECT_EX, offsetof(LPXObject, cols), READONLY,
    "Column collection.  See the help on class BarCollection."},
 #ifdef USEPARAMS
-  {"params", T_OBJECT_EX, offsetof(LPXObject, params), RO,
+  {"params", T_OBJECT_EX, offsetof(LPXObject, params), READONLY,
    "Control parameter collection.  See the help on class Params."},
 #endif
   {NULL}

--- a/src/lp.c
+++ b/src/lp.c
@@ -1257,8 +1257,7 @@ static PyMethodDef LPX_methods[] = {
 };
 
 PyTypeObject LPXType = {
-  PyObject_HEAD_INIT(NULL)
-  0,					/* ob_size */
+  PyVarObject_HEAD_INIT(NULL, 0)
   "glpk.LPX",				/* tp_name */
   sizeof(LPXObject),			/* tp_basicsize*/
   0,					/* tp_itemsize*/

--- a/src/lp.c
+++ b/src/lp.c
@@ -58,7 +58,7 @@ static int LPX_clear(LPXObject *self) {
 static void LPX_dealloc(LPXObject *self) {
   LPX_clear(self);
   if (LP) glp_delete_prob(LP);
-  self->ob_type->tp_free((PyObject*)self);
+  Py_TYPE(self)->tp_free((PyObject*)self);
 }
 
 LPXObject* LPX_FromLP(glp_prob*lp) {
@@ -202,7 +202,7 @@ static int LPX_init(LPXObject *self, PyObject *args, PyObject *kwds) {
 static PyObject* LPX_Str(LPXObject *self) {
   // Returns a string representation of this object.
   return PyString_FromFormat
-    ("<%s %d-by-%d at %p>", self->ob_type->tp_name,
+    ("<%s %d-by-%d at %p>", Py_TYPE(self)->tp_name,
      glp_get_num_rows(LP), glp_get_num_cols(LP), self);
 }
 

--- a/src/obj.c
+++ b/src/obj.c
@@ -54,7 +54,7 @@ static void ObjIter_dealloc(ObjIterObject *it) {
     PyObject_ClearWeakRefs((PyObject*)it);
   }
   Py_XDECREF(it->obj);
-  it->ob_type->tp_free((PyObject*)it);
+  Py_TYPE(it)->tp_free((PyObject*)it);
 }
 
 static Py_ssize_t ObjIter_len(ObjIterObject *it) {
@@ -132,7 +132,7 @@ static int Obj_clear(ObjObject *self) {
 
 static void Obj_dealloc(ObjObject *self) {
   Obj_clear(self);
-  self->ob_type->tp_free((PyObject*)self);
+  Py_TYPE(self)->tp_free((PyObject*)self);
 }
 
 /** Create a new bar collection object. */

--- a/src/obj.c
+++ b/src/obj.c
@@ -77,8 +77,7 @@ static PySequenceMethods objiter_as_sequence = {
 };
 
 PyTypeObject ObjIterType = {
-  PyObject_HEAD_INIT(NULL)
-  0,					/* ob_size */
+  PyVarObject_HEAD_INIT(NULL, 0)
   "glpk.ObjectiveIter",			/* tp_name */
   sizeof(ObjIterObject),		/* tp_basicsize */
   0,					/* tp_itemsize */
@@ -498,8 +497,7 @@ static PyMethodDef Obj_methods[] = {
 };
 
 PyTypeObject ObjType = {
-  PyObject_HEAD_INIT(NULL)
-  0,					/* ob_size */
+  PyVarObject_HEAD_INIT(NULL, 0)
   "glpk.Objective",			/* tp_name */
   sizeof(ObjObject),			/* tp_basicsize*/
   0,					/* tp_itemsize*/

--- a/src/obj.c
+++ b/src/obj.c
@@ -17,6 +17,8 @@ You should have received a copy of the GNU General Public License
 along with PyGLPK.  If not, see <http://www.gnu.org/licenses/>.
 **************************************************************************/
 
+#include "py3k.h"
+
 #include "obj.h"
 #include "barcol.h"
 #include "util.h"

--- a/src/params.c
+++ b/src/params.c
@@ -347,8 +347,7 @@ static PyMethodDef Params_methods[] = {
 };
 
 PyTypeObject ParamsType = {
-  PyObject_HEAD_INIT(NULL)
-  0,					/* ob_size */
+  PyVarObject_HEAD_INIT(NULL, 0)
   "glpk.Params",			/* tp_name */
   sizeof(ParamsObject),			/* tp_basicsize*/
   0,					/* tp_itemsize*/

--- a/src/params.c
+++ b/src/params.c
@@ -39,7 +39,7 @@ static int Params_clear(ParamsObject *self) {
 
 static void Params_dealloc(ParamsObject *self) {
   Params_clear(self);
-  self->ob_type->tp_free((PyObject*)self);
+  Py_TYPE(self)->tp_free((PyObject*)self);
 }
 
 /** Create a new parameter collection object. */

--- a/src/params.c
+++ b/src/params.c
@@ -17,6 +17,8 @@ You should have received a copy of the GNU General Public License
 along with PyGLPK.  If not, see <http://www.gnu.org/licenses/>.
 **************************************************************************/
 
+#include "py3k.h"
+
 #include "params.h"
 #include "util.h"
 #include "structmember.h"

--- a/src/py3k.h
+++ b/src/py3k.h
@@ -2,12 +2,12 @@
 
 #if PY_MAJOR_VERSION >= 3
 
-#define PyString_Check PyBytes_Check
-#define PyString_AsString(val) PyBytes_AsString(val)
-#define PyString_FromString(val) PyBytes_FromString(val)
-#define PyString_FromFormat PyBytes_FromFormat
-#define PyString_FromFormat(format, ...) PyBytes_FromFormat(format, __VA_ARGS__)
-#define PyString_Size(val) PyBytes_Size(val)
+#define PyString_Check PyUnicode_Check
+#define PyString_AsString(val) PyUnicode_AsUTF8(val)
+#define PyString_FromString(val) PyUnicode_FromString(val)
+#define PyString_FromFormat PyUnicode_FromFormat
+#define PyString_FromFormat(format, ...) PyUnicode_FromFormat(format, __VA_ARGS__)
+#define PyString_Size(val) PyUnicode_GET_SIZE(val)
 #define PyInt_Type PyLong_Type
 #define PyInt_AS_LONG(val) val
 #define PyInt_Check(val) PyLong_Check(val)

--- a/src/py3k.h
+++ b/src/py3k.h
@@ -1,0 +1,18 @@
+#include <Python.h>
+
+#if PY_MAJOR_VERSION >= 3
+
+#define PyString_Check PyBytes_Check
+#define PyString_AsString(val) PyBytes_AsString(val)
+#define PyString_FromString(val) PyBytes_FromString(val)
+#define PyString_FromFormat PyBytes_FromFormat
+#define PyString_FromFormat(format, ...) PyBytes_FromFormat(format, __VA_ARGS__)
+#define PyString_Size(val) PyBytes_Size(val)
+#define PyInt_Type PyLong_Type
+#define PyInt_AS_LONG(val) val
+#define PyInt_Check(val) PyLong_Check(val)
+#define PyInt_FromLong(val) PyLong_FromLong(val)
+#define PyInt_AsLong(val) PyLong_AsLong(val)
+#define PyInt_FromSize_t(val) PyLong_FromSize_t(val)
+
+#endif

--- a/src/py3k.h
+++ b/src/py3k.h
@@ -9,7 +9,7 @@
 #define PyString_FromFormat(format, ...) PyUnicode_FromFormat(format, __VA_ARGS__)
 #define PyString_Size(val) PyUnicode_GET_SIZE(val)
 #define PyInt_Type PyLong_Type
-#define PyInt_AS_LONG(val) val
+#define PyInt_AS_LONG(val) PyLong_AsLong(val)
 #define PyInt_Check(val) PyLong_Check(val)
 #define PyInt_FromLong(val) PyLong_FromLong(val)
 #define PyInt_AsLong(val) PyLong_AsLong(val)

--- a/src/py3k.h
+++ b/src/py3k.h
@@ -16,3 +16,8 @@
 #define PyInt_FromSize_t(val) PyLong_FromSize_t(val)
 
 #endif
+
+#ifndef PyVarObject_HEAD_INIT
+  #define PyVarObject_HEAD_INIT(type, size) \
+          PyObject_HEAD_INIT(type) size,
+#endif

--- a/src/tree.c
+++ b/src/tree.c
@@ -63,7 +63,7 @@ static void TreeNode_dealloc(TreeNodeObject *tn) {
     PyObject_ClearWeakRefs((PyObject*)tn);
   }
   Py_XDECREF(tn->py_tree);
-  tn->ob_type->tp_free((PyObject*)tn);
+  Py_TYPE(tn)->tp_free((PyObject*)tn);
 }
 
 static PyObject* TreeNode_richcompare(TreeNodeObject *v, PyObject *w, int op) {
@@ -144,7 +144,7 @@ static PyObject* TreeNode_getactive(TreeNodeObject *self, void *closure) {
 static PyObject* TreeNode_Str(TreeNodeObject *self) {
   // Returns a string representation of this object.
   return PyString_FromFormat
-    ("<%s, %sactive subprob %d of %s %p>", self->ob_type->tp_name,
+    ("<%s, %sactive subprob %d of %s %p>", Py_TYPE(self)->tp_name,
      self->active?"":"in",
      self->subproblem, TreeType.tp_name, self->py_tree);
 }
@@ -246,7 +246,7 @@ static void TreeIter_dealloc(TreeIterObject *it) {
     PyObject_ClearWeakRefs((PyObject*)it);
   }
   Py_XDECREF(it->py_tree);
-  it->ob_type->tp_free((PyObject*)it);
+  Py_TYPE(it)->tp_free((PyObject*)it);
 }
 
 static PyObject *TreeIter_next(TreeIterObject *self) {
@@ -308,7 +308,7 @@ static void Tree_dealloc(TreeObject *self) {
     PyObject_ClearWeakRefs((PyObject*)self);
   }
   Py_XDECREF(self->py_lp);
-  self->ob_type->tp_free((PyObject*)self);
+  Py_TYPE(self)->tp_free((PyObject*)self);
 }
 
 /** Create a new parameter collection object. */

--- a/src/tree.c
+++ b/src/tree.c
@@ -152,7 +152,7 @@ static PyObject* TreeNode_Str(TreeNodeObject *self) {
 }
 
 static PyMemberDef TreeNode_members[] = {
-  {"subproblem", T_INT, offsetof(TreeNodeObject, subproblem), RO,
+  {"subproblem", T_INT, offsetof(TreeNodeObject, subproblem), READONLY,
    "The reference number of the subproblem corresponding to this node."},
   {NULL}
 };
@@ -545,7 +545,7 @@ int Tree_InitType(PyObject *module) {
 }
 
 static PyMemberDef Tree_members[] = {
-  {"lp", T_OBJECT_EX, offsetof(TreeObject, py_lp), RO,
+  {"lp", T_OBJECT_EX, offsetof(TreeObject, py_lp), READONLY,
    "Problem object used by the MIP solver."},
   {NULL}
 };

--- a/src/tree.c
+++ b/src/tree.c
@@ -184,8 +184,7 @@ static PyMethodDef TreeNode_methods[] = {
 };
 
 PyTypeObject TreeNodeType = {
-  PyObject_HEAD_INIT(NULL)
-  0,					/* ob_size */
+  PyVarObject_HEAD_INIT(NULL, 0)
   "glpk.TreeNode",				/* tp_name */
   sizeof(TreeNodeObject),			/* tp_basicsize*/
   0,					/* tp_itemsize*/
@@ -260,8 +259,7 @@ static PyObject *TreeIter_next(TreeIterObject *self) {
 }
 
 PyTypeObject TreeIterType = {
-  PyObject_HEAD_INIT(NULL)
-  0,					/* ob_size */
+  PyVarObject_HEAD_INIT(NULL, 0)
   "glpk.TreeIter",			/* tp_name */
   sizeof(TreeIterObject),		/* tp_basicsize */
   0,					/* tp_itemsize */
@@ -625,8 +623,7 @@ static PyMethodDef Tree_methods[] = {
 };
 
 PyTypeObject TreeType = {
-  PyObject_HEAD_INIT(NULL)
-  0,					/* ob_size */
+  PyVarObject_HEAD_INIT(NULL, 0)
   "glpk.Tree",				/* tp_name */
   sizeof(TreeObject),			/* tp_basicsize*/
   0,					/* tp_itemsize*/

--- a/src/tree.c
+++ b/src/tree.c
@@ -17,6 +17,8 @@ You should have received a copy of the GNU General Public License
 along with PyGLPK.  If not, see <http://www.gnu.org/licenses/>.
 **************************************************************************/
 
+#include "py3k.h"
+
 #include "tree.h"
 #include "structmember.h"
 #include "util.h"

--- a/src/util.c
+++ b/src/util.c
@@ -17,6 +17,8 @@ You should have received a copy of the GNU General Public License
 along with PyGLPK.  If not, see <http://www.gnu.org/licenses/>.
 **************************************************************************/
 
+#include "py3k.h"
+
 #include "util.h"
 #include "barcol.h"
 #include "lp.h"

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,1 +1,1 @@
-import test_glpk
+from . import test_glpk

--- a/tests/envtests.py
+++ b/tests/envtests.py
@@ -22,8 +22,8 @@ class MemoryTestCase(Runner, unittest.TestCase):
 
     def testPeakIsBound(self):
         """Tests that the peak is always greater than current."""
-        self.failUnless(env.blocks <= env.blocks_peak)
-        self.failUnless(env.bytes <= env.bytes_peak)
+        self.assertTrue(env.blocks <= env.blocks_peak)
+        self.assertTrue(env.bytes <= env.bytes_peak)
 
     def testIncrease(self):
         """Test that creating a new LPX increases the memory allocated."""
@@ -33,7 +33,7 @@ class MemoryTestCase(Runner, unittest.TestCase):
         lp.rows.add(2)
         lp.cols.add(2)
         lp.name = 'foo'
-        self.failUnless(env.bytes > bytes_first)
+        self.assertTrue(env.bytes > bytes_first)
         del lp
         gc.collect()
         self.assertEqual(env.bytes, bytes_first)
@@ -93,7 +93,7 @@ class TerminalTest(unittest.TestCase):
             self.char_count += len(s)
         env.term_hook = count_hook
         self.lp.simplex(msg_lev=LPX.MSG_ALL)
-        self.failUnless(self.char_count > 0)
+        self.assertTrue(self.char_count > 0)
 
     def testTerminalOnOff(self):
         """Test setting the terminal on and off."""
@@ -104,7 +104,7 @@ class TerminalTest(unittest.TestCase):
             self.char_count += len(s)
         env.term_hook = count_hook
         self.lp.simplex(msg_lev=LPX.MSG_ALL)
-        self.failUnless(self.char_count > 0)
+        self.assertTrue(self.char_count > 0)
         # Now turn the terminal output off.
         env.term_on = False
         oldcount = self.char_count
@@ -116,7 +116,7 @@ class TerminalTest(unittest.TestCase):
         # Now turn the terminal output back on.
         env.term_on = True
         self.lp.simplex(msg_lev=LPX.MSG_ALL)
-        self.failUnless(self.char_count > oldcount)
+        self.assertTrue(self.char_count > oldcount)
 
     def testMultipleTerminalDirect(self):
         """Test setting the hook function multiple times."""
@@ -127,17 +127,17 @@ class TerminalTest(unittest.TestCase):
             def thehook(s):
                 self.char_counts[which]+=len(s)
             return thehook
-        self.hooks = [makehook(i) for i in xrange(numhooks)]
+        self.hooks = [makehook(i) for i in range(numhooks)]
         # Randomly reset the hooks.
         rgen = random.Random(10)
-        for trial in xrange(100):
+        for trial in range(100):
             whichhook = rgen.randint(0, numhooks-1)
             env.term_hook=self.hooks[whichhook]
             old_counts = self.char_counts[:]
             self.lp.simplex(msg_lev=LPX.MSG_ALL)
             # Test that only the count associated with this hook has changed.
-            for w in xrange(numhooks):
+            for w in range(numhooks):
                 if w==whichhook:
-                    self.failUnless(self.char_counts[w] > old_counts[w])
+                    self.assertTrue(self.char_counts[w] > old_counts[w])
                 else:
                     self.assertEqual(self.char_counts[w], old_counts[w])

--- a/tests/matrixtests.py
+++ b/tests/matrixtests.py
@@ -63,8 +63,8 @@ class MatrixCoefficientTestCase(Runner, unittest.TestCase):
 
     def testMatrixSetWithImplicitIndices(self):
         """Test setting the matrix with only implicit indices."""
-        imatrix = [0.0 for r in xrange(len(self.lp.rows))
-                   for c in xrange(len(self.lp.cols))]
+        imatrix = [0.0 for r in range(len(self.lp.rows))
+                   for c in range(len(self.lp.cols))]
         for r,c,v in self.matrix:
             imatrix[r*len(self.lp.cols) + c] = float(v)
         self.lp.matrix = imatrix
@@ -99,7 +99,7 @@ class MatrixCoefficientTestCase(Runner, unittest.TestCase):
     def testSetRowVectorsWithImplicitIndices(self):
         """Test setting the matrix row by row with no indices."""
         for row in self.lp.rows:
-            vec = [0.0 for i in xrange(len(self.lp.cols))]
+            vec = [0.0 for i in range(len(self.lp.cols))]
             for c,v in self.rowVector(row.index): vec[c]=v
             row.matrix = vec
         self.checkMatrix()
@@ -119,7 +119,7 @@ class MatrixCoefficientTestCase(Runner, unittest.TestCase):
     def testSetColumnVectorsWithImplicitIndices(self):
         """Test setting the matrix column by column with no indices."""
         for col in self.lp.cols:
-            vec = [0.0 for i in xrange(len(self.lp.rows))]
+            vec = [0.0 for i in range(len(self.lp.rows))]
             for r,v in self.colVector(col.index): vec[r]=v
             col.matrix = vec
         self.checkMatrix()

--- a/tests/objtests.py
+++ b/tests/objtests.py
@@ -71,7 +71,7 @@ class ObjectiveCoefficientTestCase(Runner, unittest.TestCase):
 
     def testInitialCoefficients(self):
         """Test that the initial coefficients are 0."""
-        for i in xrange(len(self.lp.cols)):
+        for i in range(len(self.lp.cols)):
             self.assertEqual(self.lp.obj[i], 0.0)
         # While we're at it, run the same test with the iterator
         # functionality of the objective.

--- a/tests/paramtests.py
+++ b/tests/paramtests.py
@@ -47,9 +47,9 @@ class ParamsTestCase(Runner, unittest.TestCase):
             p2bt[n] = illegals
         # Integer in range 255.
         for n in 'usecuts'.split():
-            p2v[n] = xrange(0, 0x100)
+            p2v[n] = list(range(0, 0x100))
             p2bt[n] = illegals
-            p2bv[n] = tuple(xrange(-10,0)) + tuple(xrange(0x100, 0x110))
+            p2bv[n] = tuple(range(-10,0)) + tuple(range(0x100, 0x110))
 
         # FLOAT PARAMETER VALUES
 
@@ -98,7 +98,7 @@ class ParamsTestCase(Runner, unittest.TestCase):
         """Sets all parameters to their default values."""
         p2dv = dict(self.param_name2default)
         del p2dv['itcnt']
-        for pname, pvalue in p2dv.iteritems():
+        for pname, pvalue in list(p2dv.items()):
             setattr(self.lp.params, pname, pvalue)
 
     def listOfParameterPairs(self, pname2pvalues):
@@ -107,7 +107,7 @@ class ParamsTestCase(Runner, unittest.TestCase):
         Given a mapping from parameter names to a parameter value
         sequence, construct a list of all parameter names and
         parameter values."""
-        pp = [(name, value) for name, values in pname2pvalues.iteritems()
+        pp = [(name, value) for name, values in list(pname2pvalues.items())
               for value in values]
         return pp
 
@@ -127,7 +127,7 @@ class ParamsTestCase(Runner, unittest.TestCase):
         for n, v in pp:
             setattr(self.lp.params, n, v)
         self.lp.params.reset()
-        for n, v in sorted(self.param_name2default.iteritems()):
+        for n, v in sorted(self.param_name2default.items()):
             self.assertEqual(getattr(self.lp.params, n), v)
 
     def testSetBadValues(self):

--- a/tests/solvetests.py
+++ b/tests/solvetests.py
@@ -181,7 +181,7 @@ class SatisfiabilityMIPTest(unittest.TestCase):
         def lit2col(lit):
             if lit>0: return 2*lit-2
             return 2*(-lit)-1
-        for i in xrange(1, numvars+1):
+        for i in range(1, numvars+1):
             lp.cols[lit2col( i)].name =  'x_%d'%i
             lp.cols[lit2col(-i)].name = '!x_%d'%i
             lp.rows.add(1)
@@ -228,7 +228,7 @@ class SatisfiabilityMIPTest(unittest.TestCase):
         solution = self.solve_sat(exp)
         # First assert that this is a solution.
         self.assertNotEqual(solution, None)
-        self.failUnless(self.verify(exp, solution))
+        self.assertTrue(self.verify(exp, solution))
 
     def testInsolvableSat(self):
         """Test that an unsolvable satisfiability problem can't be solved."""
@@ -308,7 +308,7 @@ class MIPCallbackTest(Runner, unittest.TestCase):
         def lit2col(lit):
             if lit>0: return 2*lit-2
             return 2*(-lit)-1
-        for i in xrange(1, numvars+1):
+        for i in range(1, numvars+1):
             lp.cols[lit2col( i)].name =  'x_%d'%i
             lp.cols[lit2col(-i)].name = '!x_%d'%i
             lp.rows.add(1)
@@ -351,7 +351,7 @@ class MIPCallbackTest(Runner, unittest.TestCase):
         class Callback:
             pass
         assign = self.solve_sat(callback=Callback())
-        self.failUnless(self.verify(self.expression, assign))
+        self.assertTrue(self.verify(self.expression, assign))
 
     def testUncallableCallback(self):
         """Tests that there is an error with an uncallable callback."""
@@ -369,7 +369,7 @@ class MIPCallbackTest(Runner, unittest.TestCase):
                 self.stopped = False
             def default(self, tree):
                 # We should not be here if we have already made an error.
-                testobj.failIf(self.stopped)
+                testobj.assertFalse(self.stopped)
                 self.stopped = True
                 a = 1 / 0
         self.Callback = Callback
@@ -388,7 +388,7 @@ class MIPCallbackTest(Runner, unittest.TestCase):
         self.assertNotEqual(len(reasons), 0)
         # The reasons should not include anything other than those
         # reasons listed in the allreasons class member.
-        self.failUnless(reasons.issubset(set(self.allreasons)))
+        self.assertTrue(reasons.issubset(set(self.allreasons)))
 
     def testCallbackMatchsReasons(self):
         """Ensure that callback methods and reasons are properly matched."""
@@ -412,7 +412,7 @@ class MIPCallbackTest(Runner, unittest.TestCase):
                 self.stopped = False
             def default(self, tree):
                 # We should not be here if we have terminated.
-                testobj.failIf(self.stopped)
+                testobj.assertFalse(self.stopped)
                 self.stopped = True
                 tree.terminate()
         def rp(retval, lp):
@@ -427,9 +427,9 @@ class MIPCallbackTest(Runner, unittest.TestCase):
             def __init__(self):
                 self.last_total=0
             def default(self, tree):
-                testobj.failUnless(tree.num_active <= tree.num_all)
-                testobj.failUnless(tree.num_all <= tree.num_total)
-                testobj.failUnless(self.last_total <= tree.num_total)
+                testobj.assertTrue(tree.num_active <= tree.num_all)
+                testobj.assertTrue(tree.num_all <= tree.num_total)
+                testobj.assertTrue(self.last_total <= tree.num_total)
                 testobj.assertEqual(tree.num_active, len(list(tree)))
                 self.last_total = tree.num_total
         assign = self.solve_sat(callback=Callback())
@@ -471,7 +471,7 @@ class MIPCallbackTest(Runner, unittest.TestCase):
                 n = tree.first_node
                 while n:
                     explicit_actives.append(n.subproblem)
-                    n = n.next
+                    n = n.__next__
                 actives = [n.subproblem for n in tree]
                 testobj.assertEqual(actives, explicit_actives)
                 

--- a/tests/test_glpk.py
+++ b/tests/test_glpk.py
@@ -1,5 +1,7 @@
 """The main module for running the tests."""
 
+from __future__ import print_function
+
 from testutils import *
 
 errors, failures, total = 0, 0, 0
@@ -17,8 +19,8 @@ for name_of_test in test_names:
 # Print the final summary report.
 if errors + failures:
     import sys
-    print 'TESTS FAILED!! : %d failures, %d errors from %d tests total' % (
-        failures, errors, total)
+    print('TESTS FAILED!! : %d failures, %d errors from %d tests total' % (
+        failures, errors, total))
     sys.exit(1)
 else:
-    print 'TESTS PASSED!!  %d tests total' % total
+    print('TESTS PASSED!!  %d tests total' % total)

--- a/tests/testutils.py
+++ b/tests/testutils.py
@@ -3,6 +3,7 @@
 from __future__ import print_function
 
 import sys, os.path
+import collections
 newpath = os.path.dirname(os.path.dirname(__file__))
 sys.path.insert(0, newpath)
 
@@ -48,10 +49,10 @@ def extractSuite(obj):
     if hasattr(obj, 'suite'):
         s = obj.suite
         if issubclass(type(s), unittest.TestSuite): return s
-        if callable(s): return s()
+        if isinstance(s, collections.Callable): return s()
     # Build the test suite.
     the_suite = unittest.TestSuite()
-    for v in vars(obj).values():
+    for v in list(vars(obj).values()):
         if type(v)==type and issubclass(v, unittest.TestCase):
             subsuite = tload.loadTestsFromTestCase(v)
             the_suite.addTests(subsuite)

--- a/tests/testutils.py
+++ b/tests/testutils.py
@@ -1,5 +1,7 @@
 """Contains material useful for all the different PyGLPK test modules."""
 
+from __future__ import print_function
+
 import sys, os.path
 newpath = os.path.dirname(os.path.dirname(__file__))
 sys.path.insert(0, newpath)
@@ -61,7 +63,7 @@ def testsRunner(obj):
     This will run this module's suite function upon the passed in
     object, and run the resulting test suite upon a
     unittest.TextTestRunner."""
-    print obj.__name__, ':', obj.__doc__
+    print(obj.__name__, ':', obj.__doc__)
     return unittest.TextTestRunner(verbosity=2).run(extractSuite(obj))
 
 # The runner convenience class.

--- a/tests/vectortests.py
+++ b/tests/vectortests.py
@@ -239,7 +239,7 @@ class DeleteVectorTestCase(Runner):
     def testDeleteExtendedSliceVectorDecreasesLength(self):
         """Tests deleting columns indexed by an extended slice."""
         del self.vc[::2]
-        self.assertEqual(len(self.vc), self.num_vecs / 2)
+        self.assertEqual(len(self.vc), self.num_vecs // 2)
         self.assertEqual([v.name for v in self.vc],
                          ['x%d'%i for i in range(1, self.num_vecs, 2)])
         if env.version >= (4, 7):

--- a/tests/vectortests.py
+++ b/tests/vectortests.py
@@ -130,10 +130,10 @@ class IndexVectorTestCase(Runner):
         """Tests the 'in' operator for string indices."""
         if env.version < (4,7): return
         self.vc.add(5)
-        self.failIf('foo' in self.vc)
+        self.assertFalse('foo' in self.vc)
         self.vc[2].name = 'foo'
-        self.assert_('foo' in self.vc)
-        self.failIf('bar' in self.vc)
+        self.assertTrue('foo' in self.vc)
+        self.assertFalse('bar' in self.vc)
 
     def testStringTupleIndexingOfMultipleVector(self):
         """Tests indexing multiple vectors with a string tuple."""
@@ -162,7 +162,7 @@ class IndexVectorTestCase(Runner):
     def testSliceIndexingOfVectors(self):
         """Tests indexing vectors by slice."""
         to_add = 37
-        i = range(to_add)
+        i = list(range(to_add))
         self.vc.add(to_add)
         self.assertEqual([v.index for v in self.vc[:5]], i[:5])
         self.assertEqual([v.index for v in self.vc[:-4]], i[:-4])
@@ -188,7 +188,7 @@ class IndexVectorTestCase(Runner):
         """Tests that the vector collection may be iterated upon."""
         to_add = 78
         self.vc.add(to_add)
-        self.assertEqual([v.index for v in self.vc], range(to_add))
+        self.assertEqual([v.index for v in self.vc], list(range(to_add)))
 
     def testIteratorWriteAccessToVectors(self):
         """Tests that the vectors from iteration are mutable."""
@@ -216,7 +216,7 @@ class DeleteVectorTestCase(Runner):
         self.assertEqual(len(self.vc), self.num_vecs-1)
         self.assertEqual(self.vc[3].name, 'x4')
         if env.version < (4, 7): return
-        self.failUnless('x3' not in self.vc)
+        self.assertTrue('x3' not in self.vc)
 
     def testDeleteTupleVectorDecreasesLength(self):
         """Tests deleting columns indexed by tuple."""
@@ -231,8 +231,8 @@ class DeleteVectorTestCase(Runner):
         self.assertEqual(len(self.vc), self.num_vecs-2)
         self.assertEqual([v.name for v in self.vc], ['x2', 'x3', 'x4'])
         if env.version >= (4, 7):
-            self.failUnless('x0' not in self.vc)
-            self.failUnless('x1' not in self.vc)
+            self.assertTrue('x0' not in self.vc)
+            self.assertTrue('x1' not in self.vc)
         del self.vc[:]
         self.assertEqual(len(self.vc), 0)
 
@@ -241,10 +241,10 @@ class DeleteVectorTestCase(Runner):
         del self.vc[::2]
         self.assertEqual(len(self.vc), self.num_vecs / 2)
         self.assertEqual([v.name for v in self.vc],
-                         ['x%d'%i for i in xrange(1, self.num_vecs, 2)])
+                         ['x%d'%i for i in range(1, self.num_vecs, 2)])
         if env.version >= (4, 7):
-            for i in xrange(0, self.num_vecs, 2):
-                self.failUnless(('x%d'%i) not in self.vc)
+            for i in range(0, self.num_vecs, 2):
+                self.assertTrue(('x%d'%i) not in self.vc)
 
     def testDeleteVectorInvalidation(self):
         """Tests Bar invalidation once its index becomes out of bounds."""
@@ -423,16 +423,16 @@ class ComparisonTestCase(unittest.TestCase):
 
     def testComparisonSameCollection(self):
         """Test that vectors in the same collection are ordered by index."""
-        self.failUnless(self.r[0] < self.r[1])
-        self.failUnless(self.r[2] > self.r[1])
-        self.failUnless(self.c[2] > self.c[1])
-        self.failUnless(self.c[2] < self.c[-1])
+        self.assertTrue(self.r[0] < self.r[1])
+        self.assertTrue(self.r[2] > self.r[1])
+        self.assertTrue(self.c[2] > self.c[1])
+        self.assertTrue(self.c[2] < self.c[-1])
 
     def testComparisonDifferentCollection(self):
         """Test vector comparions in different collections."""
         a, b = self.r, self.c
         if b < a: a,b = b,a
         # A should be the lower bar collection.
-        self.failUnless(a[0] < b[0])
-        self.failUnless(b[1] > a[3])
-        self.failUnless(a[1] < b[0])
+        self.assertTrue(a[0] < b[0])
+        self.assertTrue(b[1] > a[3])
+        self.assertTrue(a[1] < b[0])


### PR DESCRIPTION
This PR brings compatibility with Python 3.x to PyGLPK. It should also support 2.7 (tested) and 2.6 (not tested).

I've taken a least effort approach to the port, following http://python3porting.com/cextensions.html and various other docs. The main changes are in module initialisation in `glpk.c` and some macros for string->unicode and int->long conversion in `py3k.h`. I've also run the test modules through `2to3`.

Ignoring outstanding issues (https://github.com/bradfordboyle/pyglpk/pull/1 and https://github.com/bradfordboyle/pyglpk/issues/2), only 1 test fails:

```
TESTS FAILED!! : 1 failures, 1 errors from 261 tests total
```

The failing test is `vectortests.py::testComparisonDifferentCollection` - it's not clear to me why this works in Python 2.x, as I can't see an explicit method to compare BarCollection objects.
