### PR TITLE
Replace bzero() with memset()

### DIFF
--- a/src/kkt.c
+++ b/src/kkt.c
@@ -34,7 +34,7 @@ static void KKT_dealloc(KKTObject *self) {
 KKTObject *KKT_New(void) {
   KKTObject *k = (KKTObject*)PyObject_New(KKTObject, &KKTType);
   if (k==NULL) return k;
-  bzero((void*)(&(k->kkt)), sizeof(pyglpk_kkt_t));
+  memset((void*)(&(k->kkt)), 0, sizeof(pyglpk_kkt_t));
   k->weakreflist = NULL;
   return k;
 }

--- a/src/kkt.c
+++ b/src/kkt.c
@@ -34,7 +34,7 @@ static void KKT_dealloc(KKTObject *self) {
 KKTObject *KKT_New(void) {
   KKTObject *k = (KKTObject*)PyObject_New(KKTObject, &KKTType);
   if (k==NULL) return k;
-  memset((void*)(&(k->kkt)), 0, sizeof(pyglpk_kkt_t));
+  memset(&k->kkt, 0, sizeof(pyglpk_kkt_t));
   k->weakreflist = NULL;
   return k;
 }

--- a/src/kkt.c
+++ b/src/kkt.c
@@ -184,9 +184,9 @@ static PyGetSetDef KKT_getset[] = {
    "Character representing the quality of primal feasibility.\n"
    "'H', high, 'M', medium, 'L', low, or '?' wrong or infeasible."},
 
-  {"de_ae_row", (getter)KKT_de_ae_col, (setter)NULL,
+  {"de_ae_col", (getter)KKT_de_ae_col, (setter)NULL,
    "Index of the column with the largest absolute error."},
-  {"de_re_row", (getter)KKT_de_re_col, (setter)NULL,
+  {"de_re_col", (getter)KKT_de_re_col, (setter)NULL,
    "Index of the column with the largest relative error."},
   {"de_quality", (getter)KKT_de_quality, (setter)NULL,
    "Character representing the quality of the primal solution.\n"

--- a/src/kkt.c
+++ b/src/kkt.c
@@ -184,9 +184,9 @@ static PyGetSetDef KKT_getset[] = {
    "Character representing the quality of primal feasibility.\n"
    "'H', high, 'M', medium, 'L', low, or '?' wrong or infeasible."},
 
-  {"de_ae_col", (getter)KKT_de_ae_col, (setter)NULL,
+  {"de_ae_row", (getter)KKT_de_ae_col, (setter)NULL,
    "Index of the column with the largest absolute error."},
-  {"de_re_col", (getter)KKT_de_re_col, (setter)NULL,
+  {"de_re_row", (getter)KKT_de_re_col, (setter)NULL,
    "Index of the column with the largest relative error."},
   {"de_quality", (getter)KKT_de_quality, (setter)NULL,
    "Character representing the quality of the primal solution.\n"

--- a/tests/solvetests.py
+++ b/tests/solvetests.py
@@ -77,8 +77,8 @@ class SimpleSolverTest(unittest.TestCase):
         self.assertTrue(kkt.pb_re_ind in [0, 1, 2, 3])
 
         # Dual equality constraints (one for each column)
-        self.assertTrue(kkt.de_ae_col in [0, 1, 2])
-        self.assertTrue(kkt.de_re_col in [0, 1, 2])
+        self.assertTrue(kkt.de_ae_row in [0, 1, 2])
+        self.assertTrue(kkt.de_re_row in [0, 1, 2])
 
         # Dual bound constraints (one for each variable)
         self.assertTrue(kkt.db_ae_ind in [0, 1, 2, 3])
@@ -126,8 +126,8 @@ class SimpleSolverTest(unittest.TestCase):
         self.assertTrue(kkt.pb_re_ind in [0, 1, 2, 3])
 
         # Dual equality constraints (one for each column)
-        self.assertTrue(kkt.de_ae_col in [0, 1, 2])
-        self.assertTrue(kkt.de_re_col in [0, 1, 2])
+        self.assertTrue(kkt.de_ae_row in [0, 1, 2])
+        self.assertTrue(kkt.de_re_row in [0, 1, 2])
 
         # Dual bound constraints (one for each variable)
         self.assertTrue(kkt.db_ae_ind in [0, 1, 2, 3])

--- a/tests/solvetests.py
+++ b/tests/solvetests.py
@@ -41,6 +41,105 @@ class SimpleSolverTest(unittest.TestCase):
         self.assertAlmostEqual(self.lp.cols['x'].value, 1.0)
         self.assertAlmostEqual(self.lp.cols['y'].value, 0.5)
 
+    def testSimplexKKT(self):
+        """Tests the KKT check with solution from simplex solver."""
+        # Solve test LP using the simplex method,
+        # check KKT conditions on optimal solution
+        self.lp.simplex()
+        kkt = self.lp.kkt()
+
+        # The test LP has an optimal solution.
+        # The KKT conditions should be (approximately) satisfied.
+        self.assertAlmostEqual(kkt.pe_ae_max, 0.0)
+        self.assertAlmostEqual(kkt.pe_re_max, 0.0)
+        self.assertAlmostEqual(kkt.pb_ae_max, 0.0)
+        self.assertAlmostEqual(kkt.pb_re_max, 0.0)
+        self.assertAlmostEqual(kkt.de_ae_max, 0.0)
+        self.assertAlmostEqual(kkt.de_re_max, 0.0)
+        self.assertAlmostEqual(kkt.db_ae_max, 0.0)
+        self.assertAlmostEqual(kkt.db_re_max, 0.0)
+
+        # Are the row/column/variable vertices valid?
+        # In the test LP, there is:
+        # - 1 row
+        # - 2 columns
+        # - 3 variables (rows + columns)
+        # If the error reported is exactly 0, then glp_check_kkt
+        # returns an index of 0.
+
+        # Primal equality constraints (one for each row)
+        self.assertTrue(kkt.pe_ae_row in [0, 1])
+        self.assertTrue(kkt.pe_re_row in [0, 1])
+
+        # Primal bound constraints (one for each variable)
+        # There are one row and two columns in the test LP.
+        self.assertTrue(kkt.pb_ae_ind in [0, 1, 2, 3])
+        self.assertTrue(kkt.pb_re_ind in [0, 1, 2, 3])
+
+        # Dual equality constraints (one for each column)
+        self.assertTrue(kkt.de_ae_col in [0, 1, 2])
+        self.assertTrue(kkt.de_re_col in [0, 1, 2])
+
+        # Dual bound constraints (one for each variable)
+        self.assertTrue(kkt.db_ae_ind in [0, 1, 2, 3])
+        self.assertTrue(kkt.db_re_ind in [0, 1, 2, 3])
+
+        # Are the KKT "quality" values valid?
+        self.assertTrue(kkt.pe_quality in ['H', 'M', 'L', '?'])
+        self.assertTrue(kkt.pb_quality in ['H', 'M', 'L', '?'])
+        self.assertTrue(kkt.de_quality in ['H', 'M', 'L', '?'])
+        self.assertTrue(kkt.db_quality in ['H', 'M', 'L', '?'])
+
+    def testExactKKT(self):
+        """Tests the KKT check with solution from exact solver."""
+        # Solve test LP using the simplex method,
+        # check KKT conditions on optimal solution
+        self.lp.exact()
+        kkt = self.lp.kkt()
+
+        # The test LP has an optimal solution.
+        # The KKT conditions should be (approximately) satisfied.
+        self.assertAlmostEqual(kkt.pe_ae_max, 0.0)
+        self.assertAlmostEqual(kkt.pe_re_max, 0.0)
+        self.assertAlmostEqual(kkt.pb_ae_max, 0.0)
+        self.assertAlmostEqual(kkt.pb_re_max, 0.0)
+        self.assertAlmostEqual(kkt.de_ae_max, 0.0)
+        self.assertAlmostEqual(kkt.de_re_max, 0.0)
+        self.assertAlmostEqual(kkt.db_ae_max, 0.0)
+        self.assertAlmostEqual(kkt.db_re_max, 0.0)
+
+        # Are the row/column/variable vertices valid?
+        # In the test LP, there is:
+        # - 1 row
+        # - 2 columns
+        # - 3 variables (rows + columns)
+        # If the error reported is exactly 0, then glp_check_kkt
+        # returns an index of 0.
+
+        # Primal equality constraints (one for each row)
+        self.assertTrue(kkt.pe_ae_row in [0, 1])
+        self.assertTrue(kkt.pe_re_row in [0, 1])
+
+        # Primal bound constraints (one for each variable)
+        # There are one row and two columns in the test LP.
+        self.assertTrue(kkt.pb_ae_ind in [0, 1, 2, 3])
+        self.assertTrue(kkt.pb_re_ind in [0, 1, 2, 3])
+
+        # Dual equality constraints (one for each column)
+        self.assertTrue(kkt.de_ae_col in [0, 1, 2])
+        self.assertTrue(kkt.de_re_col in [0, 1, 2])
+
+        # Dual bound constraints (one for each variable)
+        self.assertTrue(kkt.db_ae_ind in [0, 1, 2, 3])
+        self.assertTrue(kkt.db_re_ind in [0, 1, 2, 3])
+
+        # Are the KKT "quality" values valid?
+        self.assertTrue(kkt.pe_quality in ['H', 'M', 'L', '?'])
+        self.assertTrue(kkt.pb_quality in ['H', 'M', 'L', '?'])
+        self.assertTrue(kkt.de_quality in ['H', 'M', 'L', '?'])
+        self.assertTrue(kkt.db_quality in ['H', 'M', 'L', '?'])
+
+
 class TwoDimensionalTest(unittest.TestCase):
     def setUp(self):
         self.lp = LPX()

--- a/tests/solvetests.py
+++ b/tests/solvetests.py
@@ -143,7 +143,7 @@ class SimpleSolverTest(unittest.TestCase):
 class SimpleIntegerSolverTest(unittest.TestCase):
     """A simple suite of tests for this problem.
 
-    max (x+y) subject to
+    max (2*x+y) subject to
     0.5*x + y <= 1
     0 <= x <= 1
     0 <= y <= 1
@@ -159,7 +159,7 @@ class SimpleIntegerSolverTest(unittest.TestCase):
         for c in lp.cols:
             c.bounds = 0,1
             c.kind = int
-        lp.obj[:] = [1,1]
+        lp.obj[:] = [2,1]
         lp.obj.maximize = True
         lp.rows[0].matrix = [0.5, 1.0]
         lp.rows[0].bounds = None, 1

--- a/tests/solvetests.py
+++ b/tests/solvetests.py
@@ -59,8 +59,8 @@ class SimpleSolverTest(unittest.TestCase):
         self.assertAlmostEqual(kkt.db_ae_max, 0.0)
         self.assertAlmostEqual(kkt.db_re_max, 0.0)
 
-        # Are the row/column/variable vertices valid?
-        # In the test LP, there is:
+        # Are the row/column/variable indices valid?
+        # In the test LP, there are:
         # - 1 row
         # - 2 columns
         # - 3 variables (rows + columns)
@@ -108,8 +108,8 @@ class SimpleSolverTest(unittest.TestCase):
         self.assertAlmostEqual(kkt.db_ae_max, 0.0)
         self.assertAlmostEqual(kkt.db_re_max, 0.0)
 
-        # Are the row/column/variable vertices valid?
-        # In the test LP, there is:
+        # Are the row/column/variable indices valid?
+        # In the test LP, there are:
         # - 1 row
         # - 2 columns
         # - 3 variables (rows + columns)
@@ -177,15 +177,15 @@ class SimpleIntegerSolverTest(unittest.TestCase):
         self.lp.integer(presolve=True)
         kkt = self.lp.kktint()
 
-        # The test LP has an optimal solution.
+        # The test IP has an optimal solution.
         # The primal KKT conditions should be (approximately) satisfied.
         self.assertAlmostEqual(kkt.pe_ae_max, 0.0)
         self.assertAlmostEqual(kkt.pe_re_max, 0.0)
         self.assertAlmostEqual(kkt.pb_ae_max, 0.0)
         self.assertAlmostEqual(kkt.pb_re_max, 0.0)
 
-        # Are the row/column/variable vertices valid?
-        # In the test LP, there is:
+        # Are the row/column/variable indices valid?
+        # In the test IP, there are:
         # - 1 row
         # - 2 columns
         # - 3 variables (rows + columns)


### PR DESCRIPTION
I replaced `bzero()` in `kkt.c` with `memset()`. 

I did this in order to get pyglpk to compile on Windows with MSVC 2015. Apparently, `bzero()` is deprecated - from its (Linux) man page:

> This function is deprecated (marked as LEGACY in POSIX.1-2001): use memset(3) in new programs.  POSIX.1-2008 removes the specification of bzero().
