### PR TITLE
Follow symlinks when guessing glpk path

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ else:
     glpsol_path = os.popen('which glpsol').read().strip()
     # If we can't find it, just hope that the default libs are correct.
     if glpsol_path:
-        glpsol_path = os.path.abspath(glpsol_path)
+        glpsol_path = os.path.realpath(os.path.abspath(glpsol_path))
         head, tail = os.path.split(glpsol_path)
         head, tail = os.path.split(head)
         libdirs.append(os.path.join(head, 'lib'))


### PR DESCRIPTION
In some cases, glpk could be installed in a custom location, and glpsol is symlinked from a directory in PATH. In such cases, "which glpsol" returns the symlink location, and the symlinks need to be followed to find the actual glpk installation dir. "os.path.realpath" does exactly that.

In such a setup it is often also necessary to set LDFLAGS to tell the compiled library where to look for the dynamically-linked glpk library. On Linux with gcc it would be

    LDFLAGS=-Wl,rpath=<directory-with-glpk.so>
