### PR TITLE
Add user config for custom GLPK location

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,7 @@ clean:
 	@rm -f glpk.so
 
 cleaner: clean
+	@rm -rf .tox
 	find . -name "*~" -delete
 	find . -name "*.pyc" -delete
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist =
     2.7-cover,
-    3.5-cover
+    3.6-cover
 
 [testenv]
 deps=pytest


### PR DESCRIPTION
This commit add user configuration to "setup.py" that allows for custom
GLPK install location. The user can either specify `--with-glpk=<path>`
or `GLPK=<path>` environment variable. If both are specified, the
command line option takes precedence. In both cases, it is assumed that
glpk is *not* located on the C compiler's library path and rpath is set.