### PR TITLE
Use C99-style designated initializers

### DIFF
--- a/src/bar.c
+++ b/src/bar.c
@@ -662,45 +662,22 @@ PyDoc_STRVAR(bar_doc,
 
 PyTypeObject BarType = {
   PyVarObject_HEAD_INIT(NULL, 0)
-  "glpk.Bar",				/* tp_name */
-  sizeof(BarObject),			/* tp_basicsize*/
-  0,					/* tp_itemsize*/
-  (destructor)Bar_dealloc,		/* tp_dealloc*/
-  0,					/* tp_print*/
-  0,					/* tp_getattr*/
-  0,					/* tp_setattr*/
-  0,					/* tp_compare*/
-  (reprfunc)Bar_Str,			/* tp_repr*/
-  0,					/* tp_as_number*/
-  0, //&Bar_as_sequence,		/* tp_as_sequence*/
-  0, //&Bar_as_mapping,			/* tp_as_mapping*/
-  0,					/* tp_hash */
-  0,					/* tp_call*/
-  (reprfunc)Bar_Str,			/* tp_str*/
-  0,					/* tp_getattro*/
-  0,					/* tp_setattro*/
-  0,					/* tp_as_buffer*/
+  .tp_name           = "glpk.Bar",
+  .tp_basicsize      = sizeof(BarObject),
+  .tp_dealloc        = (destructor) Bar_dealloc,
+  .tp_repr           = (reprfunc) Bar_Str,
+  .tp_str            = (reprfunc)Bar_Str,
 #ifdef USE_BAR_GC
-  Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE | Py_TPFLAGS_HAVE_GC,/* tp_flags*/
+  .tp_flags          = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE | Py_TPFLAGS_HAVE_GC,
 #else
-  Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE, /* tp_flags*/
+  .tp_flags          = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE,
 #endif
-  bar_doc,			/* tp_doc */
-  (traverseproc)Bar_traverse,		/* tp_traverse */
-  (inquiry)Bar_clear,			/* tp_clear */
-  (richcmpfunc)Bar_richcompare,		/* tp_richcompare */
-  offsetof(BarObject, weakreflist),	/* tp_weaklistoffset */
-  0,					/* tp_iter */
-  0,					/* tp_iternext */
-  Bar_methods,				/* tp_methods */
-  Bar_members,				/* tp_members */
-  Bar_getset,				/* tp_getset */
-  //0,					/* tp_base */
-  //0,					/* tp_dict */
-  //0,					/* tp_descr_get */
-  //0,					/* tp_descr_set */
-  //0,					/* tp_dictoffset */
-  //(initproc)Bar_init,			/* tp_init */
-  //0,					/* tp_alloc */
-  //Bar_new,				/* tp_new */
+  .tp_doc            = bar_doc,
+  .tp_traverse       = (traverseproc) Bar_traverse,
+  .tp_clear          = (inquiry) Bar_clear,
+  .tp_richcompare    = (richcmpfunc) Bar_richcompare,
+  .tp_weaklistoffset = offsetof(BarObject, weakreflist),
+  .tp_methods        = Bar_methods,
+  .tp_members        = Bar_members,
+  .tp_getset         = Bar_getset,
 };

--- a/src/barcol.c
+++ b/src/barcol.c
@@ -85,40 +85,16 @@ PyDoc_STRVAR(barcoliter_doc,
 
 PyTypeObject BarColIterType = {
   PyVarObject_HEAD_INIT(NULL, 0)
-  "glpk.BarCollectionIter",		/* tp_name */
-  sizeof(BarColIterObject),		/* tp_basicsize */
-  0,					/* tp_itemsize */
-  (destructor)BarColIter_dealloc,	/* tp_dealloc */
-  0,					/* tp_print */
-  0,					/* tp_getattr */
-  0,					/* tp_setattr */
-  0,					/* tp_compare */
-  0,					/* tp_repr */
-  0,					/* tp_as_number */
-  &bciter_as_sequence,			/* tp_as_sequence */
-  0,					/* tp_as_mapping */
-  0,					/* tp_hash */
-  0,					/* tp_call */
-  0,					/* tp_str */
-  PyObject_GenericGetAttr,		/* tp_getattro */
-  0,					/* tp_setattro */
-  0,					/* tp_as_buffer */
-  Py_TPFLAGS_DEFAULT,			/* tp_flags */
-  barcoliter_doc,	/* tp_doc */
-  0,					/* tp_traverse */
-  0,					/* tp_clear */
-  0,					/* tp_richcompare */
-  offsetof(BarColIterObject, weakreflist),	/* tp_weaklistoffset */
-  PyObject_SelfIter,			/* tp_iter */
-  (iternextfunc)BarColIter_next,	/* tp_iternext */
-  0,					/* tp_methods */
-  0,					/* tp_members */
-  0,					/* tp_getset */
-  0,					/* tp_base */
-  0,					/* tp_dict */
-  0,					/* tp_descr_get */
-  0,					/* tp_descr_set */
-  0,					/* tp_dictoffset */
+  .tp_name           = "glpk.BarCollectionIter",
+  .tp_basicsize      = sizeof(BarColIterObject),
+  .tp_dealloc        = (destructor) BarColIter_dealloc,
+  .tp_as_sequence    = &bciter_as_sequence,
+  .tp_getattro       = PyObject_GenericGetAttr,
+  .tp_flags          = Py_TPFLAGS_DEFAULT,
+  .tp_doc            = barcoliter_doc,
+  .tp_weaklistoffset = offsetof(BarColIterObject, weakreflist),
+  .tp_iter           = PyObject_SelfIter,
+  .tp_iternext       = (iternextfunc)BarColIter_next,
 };
 
 /** BAR COLLECTION OBJECT IMPLEMENTATION **/
@@ -519,45 +495,22 @@ static PyMethodDef BarCol_methods[] = {
 
 PyTypeObject BarColType = {
   PyVarObject_HEAD_INIT(NULL, 0)
-  "glpk.BarCollection",			/* tp_name */
-  sizeof(BarColObject),			/* tp_basicsize*/
-  0,					/* tp_itemsize*/
-  (destructor)BarCol_dealloc,		/* tp_dealloc*/
-  0,					/* tp_print*/
-  0,					/* tp_getattr*/
-  0,					/* tp_setattr*/
-  0,					/* tp_compare*/
-  0,					/* tp_repr*/
-  0,					/* tp_as_number*/
-  &BarCol_as_sequence,			/* tp_as_sequence*/
-  &BarCol_as_mapping,			/* tp_as_mapping*/
-  0,					/* tp_hash */
-  0,					/* tp_call*/
-  (reprfunc)BarCol_Str,			/* tp_str*/
-  0,					/* tp_getattro*/
-  0,					/* tp_setattro*/
-  0,					/* tp_as_buffer*/
-  Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE | Py_TPFLAGS_HAVE_GC,/* tp_flags*/
-  barcol_doc,	/* tp_doc */
-  (traverseproc)BarCol_traverse,	/* tp_traverse */
-  (inquiry)BarCol_clear,		/* tp_clear */
+  .tp_name           = "glpk.BarCollection",
+  .tp_basicsize      = sizeof(BarColObject),
+  .tp_dealloc        = (destructor) BarCol_dealloc,
+  .tp_as_sequence    = &BarCol_as_sequence,
+  .tp_as_mapping     = &BarCol_as_mapping,
+  .tp_str            = (reprfunc) BarCol_Str,
+  .tp_flags          = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE | Py_TPFLAGS_HAVE_GC,
+  .tp_doc            = barcol_doc,
+  .tp_traverse       = (traverseproc) BarCol_traverse,
+  .tp_clear          = (inquiry) BarCol_clear,
 #if PY_MAJOR_VERSION >= 3
-  (richcmpfunc)BarCol_richcompare, /* tp_richcompare */
-#else
-  0, /* tp_richcompare */
+  .tp_richcompare    = (richcmpfunc) BarCol_richcompare,
 #endif
-  offsetof(BarColObject, weakreflist),	/* tp_weaklistoffset */
-  BarCol_Iter,				/* tp_iter */
-  0,					/* tp_iternext */
-  BarCol_methods,			/* tp_methods */
-  BarCol_members,			/* tp_members */
-  BarCol_getset,			/* tp_getset */
-  //0,					/* tp_base */
-  //0,					/* tp_dict */
-  //0,					/* tp_descr_get */
-  //0,					/* tp_descr_set */
-  //0,					/* tp_dictoffset */
-  //(initproc)BarCol_init,		/* tp_init */
-  //0,					/* tp_alloc */
-  //BarCol_new,				/* tp_new */
+  .tp_weaklistoffset = offsetof(BarColObject, weakreflist),
+  .tp_iter           = BarCol_Iter,
+  .tp_methods        = BarCol_methods,
+  .tp_members        = BarCol_members,
+  .tp_getset         = BarCol_getset,
 };

--- a/src/environment.c
+++ b/src/environment.c
@@ -300,34 +300,16 @@ ENVIRONMENT_INSTANCE_NAME " in the\n"
 );
 
 PyTypeObject EnvironmentType = {
-	PyVarObject_HEAD_INIT(NULL, 0)
-	"glpk.Environment",			/* tp_name */
-	sizeof(EnvironmentObject),		/* tp_basicsize*/
-	0,					/* tp_itemsize*/
-	(destructor)Environment_dealloc,	/* tp_dealloc*/
-	0,					/* tp_print*/
-	0,					/* tp_getattr*/
-	0,					/* tp_setattr*/
-	0,					/* tp_compare*/
-	0,					/* tp_repr*/
-	0,					/* tp_as_number*/
-	0,					/* tp_as_sequence*/
-	0,					/* tp_as_mapping*/
-	0,					/* tp_hash */
-	0,					/* tp_call*/
-	0,					/* tp_str*/
-	0,					/* tp_getattro*/
-	0,					/* tp_setattro*/
-	0,					/* tp_as_buffer*/
-	Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE | Py_TPFLAGS_HAVE_GC,/* tp_flags*/
-	env_doc,			/* tp_doc */
-	(traverseproc)Environment_traverse,	/* tp_traverse */
-	(inquiry)Environment_clear,		/* tp_clear */
-	0,					/* tp_richcompare */
-	offsetof(EnvironmentObject, weakreflist),	/* tp_weaklistoffset */
-	0,					/* tp_iter */
-	0,					/* tp_iternext */
-	Environment_methods,			/* tp_methods */
-	Environment_members,			/* tp_members */
-	Environment_getset,			/* tp_getset */
+    PyVarObject_HEAD_INIT(NULL, 0)
+    .tp_name           = "glpk.Environment",
+    .tp_basicsize      = sizeof(EnvironmentObject),
+    .tp_dealloc        = (destructor) Environment_dealloc,
+    .tp_flags          = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE | Py_TPFLAGS_HAVE_GC,
+    .tp_doc            = env_doc,
+    .tp_traverse       = (traverseproc) Environment_traverse,
+    .tp_clear          = (inquiry) Environment_clear,
+    .tp_weaklistoffset = offsetof(EnvironmentObject, weakreflist),
+    .tp_methods        = Environment_methods,
+    .tp_members        = Environment_members,
+    .tp_getset         = Environment_getset,
 };

--- a/src/kkt.c
+++ b/src/kkt.c
@@ -273,35 +273,14 @@ PyDoc_STRVAR(kkt_doc,
 );
 
 PyTypeObject KKTType = {
-  PyVarObject_HEAD_INIT(NULL, 0)
-  "glpk.KKT",				/* tp_name */
-  sizeof(KKTObject),			/* tp_basicsize*/
-  0,					/* tp_itemsize*/
-  (destructor)KKT_dealloc,		/* tp_dealloc*/
-  0,					/* tp_print*/
-  0,					/* tp_getattr*/
-  0,					/* tp_setattr*/
-  0,					/* tp_compare*/
-  0,					/* tp_repr*/
-  0,					/* tp_as_number*/
-  0,					/* tp_as_sequence*/
-  0,					/* tp_as_mapping*/
-  0,					/* tp_hash */
-  0,					/* tp_call*/
-  0,					/* tp_str*/
-  0,					/* tp_getattro*/
-  0,					/* tp_setattro*/
-  0,					/* tp_as_buffer*/
-  Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE, /* tp_flags*/
-  kkt_doc,
-	/* tp_doc */
-  0,					/* tp_traverse */
-  0,					/* tp_clear */
-  0,					/* tp_richcompare */
-  offsetof(KKTObject, weakreflist),	/* tp_weaklistoffset */
-  0,					/* tp_iter */
-  0,					/* tp_iternext */
-  KKT_methods,				/* tp_methods */
-  KKT_members,				/* tp_members */
-  KKT_getset,				/* tp_getset */
+    PyVarObject_HEAD_INIT(NULL, 0)
+    .tp_name           = "glpk.KKT",
+    .tp_basicsize      = sizeof(KKTObject),
+    .tp_dealloc        = (destructor) KKT_dealloc,
+    .tp_flags          = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE,
+    .tp_doc            = kkt_doc,
+    .tp_weaklistoffset = offsetof(KKTObject, weakreflist),
+    .tp_methods        = KKT_methods,
+    .tp_members        = KKT_members,
+    .tp_getset         = KKT_getset,
 };

--- a/src/lp.c
+++ b/src/lp.c
@@ -1699,42 +1699,20 @@ PyDoc_STRVAR(lpx_doc,
 );
 
 PyTypeObject LPXType = {
-	PyVarObject_HEAD_INIT(NULL, 0)
-	"glpk.LPX",				/* tp_name */
-	sizeof(LPXObject),			/* tp_basicsize*/
-	0,					/* tp_itemsize*/
-	(destructor)LPX_dealloc,		/* tp_dealloc*/
-	0,					/* tp_print*/
-	0,					/* tp_getattr*/
-	0,					/* tp_setattr*/
-	0,					/* tp_compare*/
-	(reprfunc)LPX_Str,			/* tp_repr*/
-	0,					/* tp_as_number*/
-	0,					/* tp_as_sequence*/
-	0,					/* tp_as_mapping*/
-	0,					/* tp_hash */
-	0,					/* tp_call*/
-	(reprfunc)LPX_Str,			/* tp_str*/
-	0,					/* tp_getattro*/
-	0,					/* tp_setattro*/
-	0,					/* tp_as_buffer*/
-	Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE | Py_TPFLAGS_HAVE_GC,/* tp_flags*/
-	lpx_doc, /* tp_doc */
-	(traverseproc)LPX_traverse,		/* tp_traverse */
-	(inquiry)LPX_clear,			/* tp_clear */
-	0,					/* tp_richcompare */
-	offsetof(LPXObject, weakreflist),	/* tp_weaklistoffset */
-	0,					/* tp_iter */
-	0,					/* tp_iternext */
-	LPX_methods,				/* tp_methods */
-	LPX_members,				/* tp_members */
-	LPX_getset,				/* tp_getset */
-	0,					/* tp_base */
-	NULL,					/* tp_dict */
-	0,					/* tp_descr_get */
-	0,					/* tp_descr_set */
-	0,					/* tp_dictoffset */
-	(initproc)LPX_init,			/* tp_init */
-	0,					/* tp_alloc */
-	LPX_new,				/* tp_new */
+    PyVarObject_HEAD_INIT(NULL, 0)
+    .tp_name      = "glpk.LPX",
+    .tp_basicsize = sizeof(LPXObject),
+    .tp_dealloc   = (destructor)LPX_dealloc,
+    .tp_repr      = (reprfunc)LPX_Str,
+    .tp_str       = (reprfunc)LPX_Str,
+    .tp_flags     = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE | Py_TPFLAGS_HAVE_GC,
+    .tp_doc       = lpx_doc,
+    .tp_traverse  = (traverseproc)LPX_traverse,
+    .tp_clear     = (inquiry)LPX_clear,
+    .tp_weaklistoffset = offsetof(LPXObject, weakreflist),
+    .tp_methods   = LPX_methods,
+    .tp_members   = LPX_members,
+    .tp_getset    = LPX_getset,
+    .tp_init      = (initproc)LPX_init,
+    .tp_new       = LPX_new,
 };

--- a/src/obj.c
+++ b/src/obj.c
@@ -71,48 +71,26 @@ static PyObject *ObjIter_next(ObjIterObject *it) {
 }
 
 static PySequenceMethods objiter_as_sequence = {
-  (lenfunc)ObjIter_len, /* sq_length */
-  0, /* sq_concat */
+    .sq_length = (lenfunc) ObjIter_len,
 };
 
+PyDoc_STRVAR(obj_iter_doc,
+"Objective function iterator objects, used to cycle over the coefficients of\n"
+"the objective function."
+);
+
 PyTypeObject ObjIterType = {
-  PyVarObject_HEAD_INIT(NULL, 0)
-  "glpk.ObjectiveIter",			/* tp_name */
-  sizeof(ObjIterObject),		/* tp_basicsize */
-  0,					/* tp_itemsize */
-  (destructor)ObjIter_dealloc,		/* tp_dealloc */
-  0,					/* tp_print */
-  0,					/* tp_getattr */
-  0,					/* tp_setattr */
-  0,					/* tp_compare */
-  0,					/* tp_repr */
-  0,					/* tp_as_number */
-  &objiter_as_sequence,			/* tp_as_sequence */
-  0,					/* tp_as_mapping */
-  0,					/* tp_hash */
-  0,					/* tp_call */
-  0,					/* tp_str */
-  PyObject_GenericGetAttr,		/* tp_getattro */
-  0,					/* tp_setattro */
-  0,					/* tp_as_buffer */
-  Py_TPFLAGS_DEFAULT,			/* tp_flags */
-  "Objective function iterator objects, used to cycle over the\n"
-  "coefficients of the objective function.",	
-  /* tp_doc */
-  0,					/* tp_traverse */
-  0,					/* tp_clear */
-  0,					/* tp_richcompare */
-  offsetof(ObjIterObject, weakreflist),	/* tp_weaklistoffset */
-  PyObject_SelfIter,			/* tp_iter */
-  (iternextfunc)ObjIter_next,		/* tp_iternext */
-  0,					/* tp_methods */
-  0,					/* tp_members */
-  0,					/* tp_getset */
-  0,					/* tp_base */
-  0,					/* tp_dict */
-  0,					/* tp_descr_get */
-  0,					/* tp_descr_set */
-  0,					/* tp_dictoffset */
+    PyVarObject_HEAD_INIT(NULL, 0)
+    .tp_name           = "glpk.ObjectiveIter",
+    .tp_basicsize      = sizeof(ObjIterObject),
+    .tp_dealloc        = (destructor)ObjIter_dealloc,
+    .tp_as_sequence    = &objiter_as_sequence,
+    .tp_getattro       = PyObject_GenericGetAttr,
+    .tp_flags          = Py_TPFLAGS_DEFAULT,
+    .tp_doc            = obj_iter_doc,
+    .tp_weaklistoffset = offsetof(ObjIterObject, weakreflist),
+    .tp_iter           = PyObject_SelfIter,
+    .tp_iternext       = (iternextfunc) ObjIter_next,
 };
 
 /************* OBJECTIVE FUNCTION OBJECT IMPLEMENTATION **********/
@@ -453,20 +431,13 @@ int Obj_InitType(PyObject *module) {
 }
 
 static PySequenceMethods Obj_as_sequence = {
-  (lenfunc)Obj_Size,			/* sq_length */
-  0,					/* sq_concat */
-  0,					/* sq_repeat */
-  0,					/* sq_item */
-  0, //(intintargfunc)svector_slice,	/* sq_slice */
-  0,					/* sq_ass_item */
-  0,					/* sq_ass_slice */
-  0, //(objobjproc)svcontains,		/* sq_contains */
+    .sq_length = (lenfunc) Obj_Size,
 };
 
 static PyMappingMethods Obj_as_mapping = {
-  (lenfunc)Obj_Size,			/* mp_length */
-  (binaryfunc)Obj_subscript,		/* mp_subscript */
-  (objobjargproc)Obj_ass_subscript	/* mp_ass_subscript */
+    .mp_length        = (lenfunc) Obj_Size,
+    .mp_subscript     = (binaryfunc) Obj_subscript,
+    .mp_ass_subscript = (objobjargproc) Obj_ass_subscript
 };
 
 static PyMemberDef Obj_members[] = {
@@ -541,43 +512,19 @@ PyDoc_STRVAR(obj_doc,
 );
 
 PyTypeObject ObjType = {
-  PyVarObject_HEAD_INIT(NULL, 0)
-  "glpk.Objective",			/* tp_name */
-  sizeof(ObjObject),			/* tp_basicsize*/
-  0,					/* tp_itemsize*/
-  (destructor)Obj_dealloc,		/* tp_dealloc*/
-  0,					/* tp_print*/
-  0,					/* tp_getattr*/
-  0,					/* tp_setattr*/
-  0,					/* tp_compare*/
-  0,					/* tp_repr*/
-  0,					/* tp_as_number*/
-  &Obj_as_sequence,			/* tp_as_sequence*/
-  &Obj_as_mapping,			/* tp_as_mapping*/
-  0,					/* tp_hash */
-  0,					/* tp_call*/
-  0,					/* tp_str*/
-  0,					/* tp_getattro*/
-  0,					/* tp_setattro*/
-  0,					/* tp_as_buffer*/
-  Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE | Py_TPFLAGS_HAVE_GC,/* tp_flags*/
-  obj_doc,
-  /* tp_doc */
-  (traverseproc)Obj_traverse,		/* tp_traverse */
-  (inquiry)Obj_clear,			/* tp_clear */
-  0,					/* tp_richcompare */
-  offsetof(ObjObject, weakreflist),	/* tp_weaklistoffset */
-  Obj_Iter,				/* tp_iter */
-  0,					/* tp_iternext */
-  Obj_methods,				/* tp_methods */
-  Obj_members,				/* tp_members */
-  Obj_getset,				/* tp_getset */
-  //0,					/* tp_base */
-  //0,					/* tp_dict */
-  //0,					/* tp_descr_get */
-  //0,					/* tp_descr_set */
-  //0,					/* tp_dictoffset */
-  //(initproc)Obj_init,			/* tp_init */
-  //0,					/* tp_alloc */
-  //Obj_new,				/* tp_new */
+    PyVarObject_HEAD_INIT(NULL, 0)
+    .tp_name           = "glpk.Objective",
+    .tp_basicsize      = sizeof(ObjObject),
+    .tp_dealloc        = (destructor) Obj_dealloc,
+    .tp_as_sequence    = &Obj_as_sequence,
+    .tp_as_mapping     = &Obj_as_mapping,
+    .tp_flags          = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE | Py_TPFLAGS_HAVE_GC,
+    .tp_doc            = obj_doc,
+    .tp_traverse       = (traverseproc) Obj_traverse,
+    .tp_clear          = (inquiry) Obj_clear,
+    .tp_weaklistoffset = offsetof(ObjObject, weakreflist),
+    .tp_iter           = Obj_Iter,
+    .tp_methods        = Obj_methods,
+    .tp_members        = Obj_members,
+    .tp_getset         = Obj_getset,
 };

--- a/src/params.c
+++ b/src/params.c
@@ -359,35 +359,16 @@ PyDoc_STRVAR(params_doc,
 );
 
 PyTypeObject ParamsType = {
-  PyVarObject_HEAD_INIT(NULL, 0)
-  "glpk.Params",			/* tp_name */
-  sizeof(ParamsObject),			/* tp_basicsize*/
-  0,					/* tp_itemsize*/
-  (destructor)Params_dealloc,		/* tp_dealloc*/
-  0,					/* tp_print*/
-  0,					/* tp_getattr*/
-  0,					/* tp_setattr*/
-  0,					/* tp_compare*/
-  0,					/* tp_repr*/
-  0,					/* tp_as_number*/
-  0,					/* tp_as_sequence*/
-  0,					/* tp_as_mapping*/
-  0,					/* tp_hash */
-  0,					/* tp_call*/
-  0,					/* tp_str*/
-  0,					/* tp_getattro*/
-  0,					/* tp_setattro*/
-  0,					/* tp_as_buffer*/
-  Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE | Py_TPFLAGS_HAVE_GC,/* tp_flags*/
-  params_doc,
-	/* tp_doc */
-  (traverseproc)Params_traverse,	/* tp_traverse */
-  (inquiry)Params_clear,		/* tp_clear */
-  0,					/* tp_richcompare */
-  offsetof(ParamsObject, weakreflist),	/* tp_weaklistoffset */
-  0,					/* tp_iter */
-  0,					/* tp_iternext */
-  Params_methods,			/* tp_methods */
-  Params_members,			/* tp_members */
-  Params_getset,			/* tp_getset */
+    PyVarObject_HEAD_INIT(NULL, 0)
+    .tp_name           = "glpk.Params",
+    .tp_basicsize      = sizeof(ParamsObject),
+    .tp_dealloc        = (destructor) Params_dealloc,
+    .tp_flags          = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE | Py_TPFLAGS_HAVE_GC,
+    .tp_doc            = params_doc,
+    .tp_traverse       = (traverseproc) Params_traverse,
+    .tp_clear          = (inquiry) Params_clear,
+    .tp_weaklistoffset = offsetof(ParamsObject, weakreflist),
+    .tp_methods        = Params_methods,
+    .tp_members        = Params_members,
+    .tp_getset         = Params_getset,
 };

--- a/src/tree.c
+++ b/src/tree.c
@@ -201,36 +201,19 @@ PyDoc_STRVAR(tree_node_doc,
 );
 
 PyTypeObject TreeNodeType = {
-  PyVarObject_HEAD_INIT(NULL, 0)
-  "glpk.TreeNode",				/* tp_name */
-  sizeof(TreeNodeObject),			/* tp_basicsize*/
-  0,					/* tp_itemsize*/
-  (destructor)TreeNode_dealloc,		/* tp_dealloc*/
-  0,					/* tp_print*/
-  0,					/* tp_getattr*/
-  0,					/* tp_setattr*/
-  0,					/* tp_compare*/
-  (reprfunc)TreeNode_Str,		/* tp_repr*/
-  0,					/* tp_as_number*/
-  0,					/* tp_as_sequence*/
-  0,					/* tp_as_mapping*/
-  0,					/* tp_hash */
-  0,					/* tp_call*/
-  (reprfunc)TreeNode_Str,		/* tp_str*/
-  0,					/* tp_getattro*/
-  0,					/* tp_setattro*/
-  0,					/* tp_as_buffer*/
-  Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE, /* tp_flags*/
-  tree_node_doc,	/* tp_doc */
-  0,					/* tp_traverse */
-  0,					/* tp_clear */
-  (richcmpfunc)TreeNode_richcompare,	/* tp_richcompare */
-  offsetof(TreeNodeObject, weakreflist),/* tp_weaklistoffset */
-  0,					/* tp_iter */
-  0,					/* tp_iternext */
-  TreeNode_methods,			/* tp_methods */
-  TreeNode_members,			/* tp_members */
-  TreeNode_getset,			/* tp_getset */
+    PyVarObject_HEAD_INIT(NULL, 0)
+    .tp_name           = "glpk.TreeNode",
+    .tp_basicsize      = sizeof(TreeNodeObject),
+    .tp_dealloc        = (destructor) TreeNode_dealloc,
+    .tp_repr           = (reprfunc) TreeNode_Str,
+    .tp_str            = (reprfunc) TreeNode_Str,
+    .tp_flags          = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE,
+    .tp_doc            = tree_node_doc,
+    .tp_richcompare    = (richcmpfunc) TreeNode_richcompare,
+    .tp_weaklistoffset = offsetof(TreeNodeObject, weakreflist),
+    .tp_methods        = TreeNode_methods,
+    .tp_members        = TreeNode_members,
+    .tp_getset         = TreeNode_getset,
 };
 
 /************************ TREE ITER IMPLEMENTATION ************************/
@@ -280,41 +263,16 @@ PyDoc_STRVAR(tree_iter_doc,
 );
 
 PyTypeObject TreeIterType = {
-  PyVarObject_HEAD_INIT(NULL, 0)
-  "glpk.TreeIter",			/* tp_name */
-  sizeof(TreeIterObject),		/* tp_basicsize */
-  0,					/* tp_itemsize */
-  (destructor)TreeIter_dealloc,		/* tp_dealloc */
-  0,					/* tp_print */
-  0,					/* tp_getattr */
-  0,					/* tp_setattr */
-  0,					/* tp_compare */
-  0,					/* tp_repr */
-  0,					/* tp_as_number */
-  0,					/* tp_as_sequence */
-  0,					/* tp_as_mapping */
-  0,					/* tp_hash */
-  0,					/* tp_call */
-  0,					/* tp_str */
-  PyObject_GenericGetAttr,		/* tp_getattro */
-  0,					/* tp_setattro */
-  0,					/* tp_as_buffer */
-  Py_TPFLAGS_DEFAULT,			/* tp_flags */
-  tree_iter_doc,	/* tp_doc */
-  0,					/* tp_traverse */
-  0,					/* tp_clear */
-  0,					/* tp_richcompare */
-  offsetof(TreeIterObject, weakreflist),/* tp_weaklistoffset */
-  PyObject_SelfIter,			/* tp_iter */
-  (iternextfunc)TreeIter_next,		/* tp_iternext */
-  0,					/* tp_methods */
-  0,					/* tp_members */
-  0,					/* tp_getset */
-  0,					/* tp_base */
-  0,					/* tp_dict */
-  0,					/* tp_descr_get */
-  0,					/* tp_descr_set */
-  0,					/* tp_dictoffset */
+    PyVarObject_HEAD_INIT(NULL, 0)
+    .tp_name           = "glpk.TreeIter",
+    .tp_basicsize      = sizeof(TreeIterObject),
+    .tp_dealloc        = (destructor)TreeIter_dealloc,
+    .tp_getattro       = PyObject_GenericGetAttr,
+    .tp_flags          = Py_TPFLAGS_DEFAULT,
+    .tp_doc            = tree_iter_doc,
+    .tp_weaklistoffset = offsetof(TreeIterObject, weakreflist),
+    .tp_iter           = PyObject_SelfIter,
+    .tp_iternext       = (iternextfunc) TreeIter_next,
 };
 
 /************************ TREE OBJECT IMPLEMENTATION ************************/
@@ -706,35 +664,15 @@ PyDoc_STRVAR(tree_doc,
 );
 
 PyTypeObject TreeType = {
-  PyVarObject_HEAD_INIT(NULL, 0)
-  "glpk.Tree",				/* tp_name */
-  sizeof(TreeObject),			/* tp_basicsize*/
-  0,					/* tp_itemsize*/
-  (destructor)Tree_dealloc,		/* tp_dealloc*/
-  0,					/* tp_print*/
-  0,					/* tp_getattr*/
-  0,					/* tp_setattr*/
-  0,					/* tp_compare*/
-  0,					/* tp_repr*/
-  0,					/* tp_as_number*/
-  0,					/* tp_as_sequence*/
-  0,					/* tp_as_mapping*/
-  0,					/* tp_hash */
-  0,					/* tp_call*/
-  0,					/* tp_str*/
-  0,					/* tp_getattro*/
-  0,					/* tp_setattro*/
-  0,					/* tp_as_buffer*/
-  Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE, /* tp_flags*/
-  tree_doc,		/* tp_doc */
-  0,					/* tp_traverse */
-  0,					/* tp_clear */
-  0,					/* tp_richcompare */
-  offsetof(TreeObject, weakreflist),	/* tp_weaklistoffset */
-  Tree_Iter,				/* tp_iter */
-  0,					/* tp_iternext */
-  Tree_methods,				/* tp_methods */
-  Tree_members,				/* tp_members */
-  Tree_getset,				/* tp_getset */
+    PyVarObject_HEAD_INIT(NULL, 0)
+    .tp_name           = "glpk.Tree",
+    .tp_basicsize      = sizeof(TreeObject),
+    .tp_dealloc        = (destructor) Tree_dealloc,
+    .tp_flags          = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE,
+    .tp_doc            = tree_doc,
+    .tp_weaklistoffset = offsetof(TreeObject, weakreflist),
+    .tp_iter           = Tree_Iter,
+    .tp_methods        = Tree_methods,
+    .tp_members        = Tree_members,
+    .tp_getset         = Tree_getset,
 };
-


### PR DESCRIPTION
The python documentation recommends using C99-style designated
initializers to avoid having to specify all `PyTypeObject` fields and
worrying about the order of the fields.