### PR TITLE
Fix ambiguously signed bit-field member

### DIFF
--- a/src/lp.h
+++ b/src/lp.h
@@ -39,7 +39,7 @@ typedef struct {
   // The last type of solver that was used.  -1 for none, 0 for
   // simplex or exact, 1 for interior point, and 2 for integer or
   // intopt.
-  int last_solver:4;
+  unsigned int last_solver:4;
   PyObject *weakreflist; // Weak reference list.
 } LPXObject;
 


### PR DESCRIPTION
From [LGTM][]:
> Bit fields with integral types should have explicit signedness only
> It is implementation specific whether an `int`-typed bit field is
> signed, so there could be unexpected sign extension or overflow.

[LGTM]: https://lgtm.com/rules/1506024027114/