### PR TITLE
add method for copying the contents LP prob instances

### DIFF
--- a/src/lp.c
+++ b/src/lp.c
@@ -300,6 +300,16 @@ static PyObject* LPX_Erase(LPXObject *self)
 	Py_RETURN_NONE;
 }
 
+static PyObject* LPX_Copy(LPXObject *self, PyObject *args)
+{
+	int names = GLP_OFF;
+	PyArg_ParseTuple(args, "|p", &names);
+	glp_prob *dest = glp_create_prob();
+	glp_copy_prob(dest, LP, names);
+
+	return LPX_FromLP(dest);
+}
+
 static PyObject* LPX_Scale(LPXObject *self, PyObject*args)
 {
 	int flags = GLP_SF_AUTO;
@@ -1392,6 +1402,11 @@ PyDoc_STRVAR(erase_doc,
 "Erase the content of this problem, restoring it to the state it was in when\n"
 "it was first created.");
 
+PyDoc_STRVAR(copy_doc,
+"copy()\n"
+"\n"
+"Copies the content of this problem into a new problem and returns it.");
+
 PyDoc_STRVAR(scale_doc,
 "scale([flags=LPX.SF_AUTO])\n"
 "\n"
@@ -1926,6 +1941,7 @@ PyDoc_STRVAR(dual_ratio_test__doc__,
 
 static PyMethodDef LPX_methods[] = {
 	{"erase", (PyCFunction)LPX_Erase, METH_NOARGS, erase_doc},
+	{"copy", (PyCFunction)LPX_Copy, METH_VARARGS, copy_doc},
 	{"scale", (PyCFunction)LPX_Scale, METH_VARARGS, scale_doc},
 	{"unscale", (PyCFunction)LPX_Unscale, METH_NOARGS, unscale_doc},
 	// Basis construction techniques for simplex solvers.

--- a/tests/basic_test.py
+++ b/tests/basic_test.py
@@ -265,6 +265,27 @@ class LpxTests(unittest.TestCase):
         self.assertEqual(len(lp.cols), 0)
         self.assertEqual(len(lp.rows), 0)
 
+    def testLpxCopy(self):
+        lp = LPX()
+        lp.cols.add(1)
+        lp.cols[0].name = 'orginal'
+
+        c1 = lp.copy(True)
+        self.assertEqual('orginal', c1.cols[0].name)
+        self.assertNotEqual(id(lp), id(c1))
+
+        c2 = lp.copy(False)
+        self.assertIsNone(c2.cols[0].name)
+        self.assertNotEqual(id(lp), id(c2))
+
+        c3 = lp.copy(False)
+        self.assertIsNone(c3.cols[0].name)
+        self.assertNotEqual(id(lp), id(c3))
+
+        shallow_copy = lp
+        self.assertEqual(id(lp), id(shallow_copy))
+
+
     def testLpxSetMatrix(self):
         lp = LPX()
         with self.assertRaises(ValueError) as cm:


### PR DESCRIPTION
A new `copy` method is added to LPX instances that takes an optional
boolean argument. If this value is `True`, the symbolic names associated
with the problem are also copied. If the argument is `False` the names
are not copied.

Closes #36.