### PR TITLE
fix incompatibility with GCC14

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,2 +1,4 @@
 [build-system]
 requires = ["setuptools>=30.3.0", "wheel", "setuptools_scm"]
+
+[tool.setuptools_scm]

--- a/src/2to3.h
+++ b/src/2to3.h
@@ -10,15 +10,16 @@
 #define PyInt_FromSize_t(v) PyLong_FromSize_t(v)
 
 #define PyString_FromString(v) PyUnicode_FromString(v)
-#define PyString_Size(o) PyUnicode_GET_SIZE(o)
 #define PyString_FromFormat(fmt, ...) PyUnicode_FromFormat(fmt, __VA_ARGS__)
 #define PyString_Check(o) PyUnicode_Check(o)
 
 #if PY_MINOR_VERSION >= 3
-#define PyString_AsString PyUnicode_AsUTF8
+#define PyString_AsString(o) PyUnicode_AsUTF8(o)
+#define PyString_Size(o) PyUnicode_GetLength(o)
 #else
 const char* PyUnicode_AsUTF8_PriorToPy33(PyObject* unicode);
 #define PyString_AsString(o) PyUnicode_AsUTF8_PriorToPy33(o)
+#define PyString_Size(o) PyUnicode_GET_SIZE(o)
 #endif
 
 #endif

--- a/src/lp.c
+++ b/src/lp.c
@@ -309,7 +309,7 @@ static PyObject* LPX_Copy(LPXObject *self, PyObject *args)
 	glp_prob *dest = glp_create_prob();
 	glp_copy_prob(dest, LP, names);
 
-	return LPX_FromLP(dest);
+	return (PyObject *) LPX_FromLP(dest);
 }
 
 static PyObject* LPX_Scale(LPXObject *self, PyObject*args)

--- a/tests/memory_test.py
+++ b/tests/memory_test.py
@@ -21,7 +21,7 @@ class GarbageCollectionTestCase(unittest.TestCase):
     reference list are currently invalid."""
     def __init__(self, name=''):
         unittest.TestCase.__init__(self, name)
-        oldfunc = getattr(self, name)
+        oldfunc = getattr(self, name, "default")
 
         class tuplesubclass(list):
             pass


### PR DESCRIPTION
Debian trixie comes with GCC14 which makes `Wincompatible-pointer-types` error.
Therefore, glpk did not install successfully.

I solved this as well as the rename of `PyUnicode_GET_SIZE` to `PyUnicode_GetLength` which errored on python3.12 installs.

closes #45 