### PR TITLE
update github action versions and used python versions

### DIFF
--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -5,16 +5,16 @@ on: [push]
 jobs:
   tests:
     name: "Python ${{ matrix.python-version }}"
-    runs-on: windows-2019
+    runs-on: windows-2022
     strategy:
       matrix:
-        python-version: ["3.7"]
+        python-version: ["3.9"]
 
     steps:
-    - uses: "actions/checkout@v3"
+    - uses: "actions/checkout@v4"
       with:
         fetch-depth: 0
-    - uses: "actions/setup-python@v4"
+    - uses: "actions/setup-python@v5"
       with:
         python-version: "${{ matrix.python-version }}"
     - name: Setup conda
@@ -32,7 +32,7 @@ jobs:
         python -m pip install --upgrade setuptools_scm
         python setup.py bdist
 
-    - uses: actions/upload-artifact@v1
+    - uses: actions/upload-artifact@v4
       with:
         name: windows-bdist
         path: dist/

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,14 +11,14 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [macos-12, ubuntu-22.04, ubuntu-20.04]
+        os: [macos-14, ubuntu-22.04, ubuntu-24.04]
         glpk: ['4.65', '5.0']
-        python-version: ['3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.9', '3.10', '3.11', '3.12']
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: set up python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
     - name: instal glpk ${{ matrix.glpk }}


### PR DESCRIPTION
This updates the CI versions as the latest main branch build failed

* python 3.8 is eol since 10.2024
* use macos-14 and ubuntu 24